### PR TITLE
Add gentoo-specific installation of dependencies

### DIFF
--- a/tasks/dependencies-Debian.yml
+++ b/tasks/dependencies-Debian.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Install necessary packages and fonts
+  apt:
+    name={{ item }}
+    update_cache=yes
+    cache_valid_time=86400
+    install-recommends=no
+    state=present
+  with_items:
+    - default-jre-headless
+    - fonts-liberation

--- a/tasks/dependencies-Gentoo.yml
+++ b/tasks/dependencies-Gentoo.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install necessary packages and fonts
+  portage:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - virtual/jre
+    - media-fonts/liberation-fonts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 # tasks file for docbuilder
-- name: Install necessary packages and fonts
-  apt:
-    name={{ item }}
-    update_cache=yes
-    cache_valid_time=86400
-    install-recommends=no
-    state=present
-  with_items:
-    - default-jre-headless
-    - fonts-liberation
+- include: dependencies-{{ ansible_os_family }}.yml
 
 - name: Check if saxon is installed
   stat: path=/usr/local/bin/saxon


### PR DESCRIPTION
Tested and now working under gentoo.
This shouldn't change the behaviour for debian/ubuntu, but you may want to test this.
